### PR TITLE
Fix header hiding information when printing.

### DIFF
--- a/website/templates/scheduleTable.html
+++ b/website/templates/scheduleTable.html
@@ -30,6 +30,12 @@
             color: #222;
         }
 
+        @media print {
+            #masthead {
+                position: static;
+            }
+        }
+
     </style>
 
     <section class="section section--singular">


### PR DESCRIPTION
modified:   www/scheduleTable/index.html

@alanderex As requested in Telegram, here is a pr to fix the issue when printing the schedule in table form (hidden info at top at every page).

This is a quick fix. A better solution for the future could be a separate print css.