### PR TITLE
Fix typo in "Stefan Behnel" (fixes #68)

### DIFF
--- a/website/content/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/contents.lr
+++ b/website/content/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/contents.lr
@@ -10,7 +10,7 @@ short_description: Panel about Python, core-devs, development, challenges, commu
 ---
 twitter_image: /static/media/twitter/7JH7XX.jpg
 ---
-speakers: Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel
+speakers: Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel
 ---
 submission_type: Panel
 ---
@@ -63,7 +63,7 @@ ambv on Github. Python core developer, Python 3.8 release manager, creator of Bl
 
 visit the speaker at: [Twitter](https://twitter.com/llanga) • [Github](https://github.com/ambv) • [Homepage](http://lukasz.langa.pl)
 
-#### Stefan Behel
+#### Stefan Behnel
 
 
 
@@ -83,7 +83,7 @@ start_time: 14:00
 ---
 day: thursday
 ---
-meta_title: Python Panel Alexander CS Hendorf Hynek Schlawack Mariatta Wijaya Łukasz Langa Stefan Behel PyConDE & PyDataBerlin 2019 conference 
+meta_title: Python Panel Alexander CS Hendorf Hynek Schlawack Mariatta Wijaya Łukasz Langa Stefan Behnel PyConDE & PyDataBerlin 2019 conference 
 ---
 meta_twitter_title: Python Panel @hendorf hynek mariatta llanga #PyConDE #PyDataBerlin #PyData
 ---

--- a/website/databags/schedule_databag.json
+++ b/website/databags/schedule_databag.json
@@ -3128,7 +3128,7 @@
                             "domains": "Community",
                             "slug": "pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel",
                             "title": "Python Panel",
-                            "speaker_names": "Alexander CS Hendorf (K\u00d6NIGSWEG), Hynek Schlawack (Variomedia AG), Mariatta Wijaya (Zapier), \u0141ukasz Langa (Python Software Foundation), Stefan Behel",
+                            "speaker_names": "Alexander CS Hendorf (K\u00d6NIGSWEG), Hynek Schlawack (Variomedia AG), Mariatta Wijaya (Zapier), \u0141ukasz Langa (Python Software Foundation), Stefan Behnel",
                             "type": "Panel",
                             "url": "/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel",
                             "plenary": "",

--- a/website/databags/schedule_databagT.json
+++ b/website/databags/schedule_databagT.json
@@ -4728,7 +4728,7 @@
                             "domains": "Community",
                             "slug": "pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel",
                             "title": "Python Panel",
-                            "speaker_names": "Alexander CS Hendorf (K\u00d6NIGSWEG), Hynek Schlawack (Variomedia AG), Mariatta Wijaya (Zapier), \u0141ukasz Langa (Python Software Foundation), Stefan Behel",
+                            "speaker_names": "Alexander CS Hendorf (K\u00d6NIGSWEG), Hynek Schlawack (Variomedia AG), Mariatta Wijaya (Zapier), \u0141ukasz Langa (Python Software Foundation), Stefan Behnel",
                             "type": "Panel",
                             "url": "/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel",
                             "plenary": "",

--- a/website/databags/schedule_databagTable.json
+++ b/website/databags/schedule_databagTable.json
@@ -1536,7 +1536,7 @@
                     "14:00",
                     {
                         "title": "Python Panel",
-                        "speakers": "Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, \u0141ukasz Langa, Stefan Behel",
+                        "speakers": "Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, \u0141ukasz Langa, Stefan Behnel",
                         "code": "pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel",
                         "slug": "pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel",
                         "subm_type": "Panel",

--- a/www/program/categories/community/index.html
+++ b/www/program/categories/community/index.html
@@ -471,7 +471,7 @@
             <h5 class="blog-list__title session_list_title">
                 <a href="/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/">Python Panel</a>
             </h5>
-            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</h6>
+            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</h6>
             <span class="blog-list__info sub-head">Community</span>
             <span class="blog-list__info sub-head"></span>
 

--- a/www/program/categories/domain-expertise-some/index.html
+++ b/www/program/categories/domain-expertise-some/index.html
@@ -1521,7 +1521,7 @@
             <h5 class="blog-list__title session_list_title">
                 <a href="/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/">Python Panel</a>
             </h5>
-            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</h6>
+            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</h6>
             <span class="blog-list__info sub-head">Community</span>
             <span class="blog-list__info sub-head"></span>
 

--- a/www/program/categories/panel/index.html
+++ b/www/program/categories/panel/index.html
@@ -296,7 +296,7 @@
             <h5 class="blog-list__title session_list_title">
                 <a href="/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/">Python Panel</a>
             </h5>
-            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</h6>
+            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</h6>
             <span class="blog-list__info sub-head">Community</span>
             <span class="blog-list__info sub-head"></span>
 

--- a/www/program/categories/pyconde/index.html
+++ b/www/program/categories/pyconde/index.html
@@ -1046,7 +1046,7 @@
             <h5 class="blog-list__title session_list_title">
                 <a href="/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/">Python Panel</a>
             </h5>
-            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</h6>
+            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</h6>
             <span class="blog-list__info sub-head">Community</span>
             <span class="blog-list__info sub-head"></span>
 

--- a/www/program/categories/python-skill-level-basic/index.html
+++ b/www/program/categories/python-skill-level-basic/index.html
@@ -1746,7 +1746,7 @@
             <h5 class="blog-list__title session_list_title">
                 <a href="/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/">Python Panel</a>
             </h5>
-            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</h6>
+            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</h6>
             <span class="blog-list__info sub-head">Community</span>
             <span class="blog-list__info sub-head"></span>
 

--- a/www/program/categories/thursday-1400/index.html
+++ b/www/program/categories/thursday-1400/index.html
@@ -346,7 +346,7 @@
             <h5 class="blog-list__title session_list_title">
                 <a href="/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/">Python Panel</a>
             </h5>
-            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</h6>
+            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</h6>
             <span class="blog-list__info sub-head">Community</span>
             <span class="blog-list__info sub-head"></span>
 

--- a/www/program/categories/thursday/index.html
+++ b/www/program/categories/thursday/index.html
@@ -1196,7 +1196,7 @@
             <h5 class="blog-list__title session_list_title">
                 <a href="/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/">Python Panel</a>
             </h5>
-            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</h6>
+            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</h6>
             <span class="blog-list__info sub-head">Community</span>
             <span class="blog-list__info sub-head"></span>
 

--- a/www/program/index.html
+++ b/www/program/index.html
@@ -2424,7 +2424,7 @@
             <h5 class="blog-list__title session_list_title">
                 <a href="/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/">Python Panel</a>
             </h5>
-            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</h6>
+            <h6 class="session_list_speaker">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</h6>
             <span class="blog-list__info sub-head">Community</span>
             <span class="blog-list__info sub-head"></span>
 

--- a/www/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/index.html
+++ b/www/program/pyconde-7jh7xx-python-panel-alexander-cs-hendorf-hynek-schlawack-mariatta-wijaya-ukasz-langa-stefan-behel/index.html
@@ -23,7 +23,7 @@
 
     <!-- other data for sharing -->
 
-    <meta  property="og:title" content="Python Panel Alexander CS Hendorf Hynek Schlawack Mariatta Wijaya Łukasz Langa Stefan Behel PyConDE &amp; PyDataBerlin 2019 conference ">
+    <meta  property="og:title" content="Python Panel Alexander CS Hendorf Hynek Schlawack Mariatta Wijaya Łukasz Langa Stefan Behnel PyConDE &amp; PyDataBerlin 2019 conference ">
 
     
         <meta  name="og:image:secure_url" content="https://de.pycon.org/static/media/twitter/7JH7XX.jpg?h=81dcd90c">
@@ -256,7 +256,7 @@
                             
                             
 
-                            <h3 class="page-title">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</h3>
+                            <h3 class="page-title">Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</h3>
 
                         </header>
 
@@ -343,7 +343,7 @@ Being a partner at <a href="https://www.koenigsweg.com/index_ger.html">Königswe
 <p>Affiliation: Python Software Foundation</p>
 <p>ambv on Github. Python core developer, Python 3.8 release manager, creator of Black, pianist, dad. Likes analog modular synthesizers, immersive single-player role playing games (Fallout, Elder Scrolls), and single malt Scotch whisky.</p>
 <p>visit the speaker at: <a href="https://twitter.com/llanga">Twitter</a> • <a href="https://github.com/ambv">Github</a> • <a href="http://lukasz.langa.pl">Homepage</a></p>
-<h4>Stefan Behel</h4>
+<h4>Stefan Behnel</h4>
 
                             </div>
 

--- a/www/schedule/index.html
+++ b/www/schedule/index.html
@@ -4866,7 +4866,7 @@
                                                                             class="fa fa-md "></i></div>
                                                                     
                                                                         <p class="clipcard__info"><span
-                                                                                class="text-body-3">Alexander CS Hendorf (KÖNIGSWEG), Hynek Schlawack (Variomedia AG), Mariatta Wijaya (Zapier), Łukasz Langa (Python Software Foundation), Stefan Behel&nbsp;</span>
+                                                                                class="text-body-3">Alexander CS Hendorf (KÖNIGSWEG), Hynek Schlawack (Variomedia AG), Mariatta Wijaya (Zapier), Łukasz Langa (Python Software Foundation), Stefan Behnel&nbsp;</span>
                                                                         </p>
                                                                     
 

--- a/www/scheduleT/index.html
+++ b/www/scheduleT/index.html
@@ -4337,7 +4337,7 @@
                                                                 </h6>
                                                                 
                                                                         <p class="clipcard__info"><span
-                                                                                class="text-body-3">Alexander CS Hendorf (KÖNIGSWEG), Hynek Schlawack (Variomedia AG), Mariatta Wijaya (Zapier), Łukasz Langa (Python Software Foundation), Stefan Behel&nbsp;</span>
+                                                                                class="text-body-3">Alexander CS Hendorf (KÖNIGSWEG), Hynek Schlawack (Variomedia AG), Mariatta Wijaya (Zapier), Łukasz Langa (Python Software Foundation), Stefan Behnel&nbsp;</span>
                                                                         </p>
                                                                     
                                                                 <span class="clipcard__subtitle"><span class="sub-head-2">PyConDE

--- a/www/scheduleTable/index.html
+++ b/www/scheduleTable/index.html
@@ -2844,7 +2844,7 @@
                                                     Python Panel
 
                                                     
-                                                        <span><br>Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behel</span>
+                                                        <span><br>Alexander CS Hendorf, Hynek Schlawack, Mariatta Wijaya, Łukasz Langa, Stefan Behnel</span>
                                                     
                                                 </a>
                                             


### PR DESCRIPTION
The result of
find . -type f | xargs sed -i 's/Stefan Behel/Stefan Behnel/g'

This changes the contents of the pages. Mis-named paths like
www/program/pyconde-7jh7xx-python-panel[...]-stefan-behel/index.html
do not get fixed, so bookmarks should not break.